### PR TITLE
Feature/FEC 11 volume slider

### DIFF
--- a/src/components/molecules/IconButton/IconButton.stories.tsx
+++ b/src/components/molecules/IconButton/IconButton.stories.tsx
@@ -1,7 +1,7 @@
 import { Flex } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
+import { AllIcons } from "components/atoms/Icon";
 
-import { AllIcons } from "../../atoms/Icon";
 import { IconButton } from "./IconButton";
 
 const meta = {

--- a/src/components/molecules/Slider/Slider.stories.tsx
+++ b/src/components/molecules/Slider/Slider.stories.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@chakra-ui/react";
+import { config } from "@storybook/addon-designs";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Slider } from "./Slider";
@@ -41,5 +42,13 @@ export const SliderStory: Story = {
   },
   args: {
     variant: "desktop",
+  },
+  parameters: {
+    design: config([
+      {
+        type: "figma",
+        url: "https://www.figma.com/file/HfIFZ2xe4LJgyCSk08SL8I/Player?type=design&node-id=30%3A46&mode=design&t=WK89mzXD1kcI4erK-1",
+      },
+    ]),
   },
 };

--- a/src/components/molecules/TrackDetails/TrackDetails.stories.tsx
+++ b/src/components/molecules/TrackDetails/TrackDetails.stories.tsx
@@ -1,3 +1,4 @@
+import { config } from "@storybook/addon-designs";
 import type { Meta, StoryObj } from "@storybook/react";
 import { testTrack1 } from "mocks/fixtures/test-tracks";
 
@@ -27,5 +28,13 @@ export const TrackDetailsStory: Story = {
     title: testTrack1.title,
     artworkUrl: testTrack1.artworkUrl,
     productUrl: testTrack1.productUrl,
+  },
+  parameters: {
+    design: config([
+      {
+        type: "figma",
+        url: "https://www.figma.com/file/HfIFZ2xe4LJgyCSk08SL8I/Player?type=design&node-id=61%3A181&mode=design&t=WK89mzXD1kcI4erK-1",
+      },
+    ]),
   },
 };

--- a/src/components/molecules/VolumeSlider/VolumeSlider.stories.tsx
+++ b/src/components/molecules/VolumeSlider/VolumeSlider.stories.tsx
@@ -2,22 +2,29 @@ import { Box } from "@chakra-ui/react";
 import { config } from "@storybook/addon-designs";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { VolumeSlider } from "./VolumeSlider";
+import { VolumeSlider, VolumeSliderContainer } from ".";
 
 const meta = {
   title: "components/VolumeSlider",
-} satisfies Meta<typeof VolumeSlider>;
+} satisfies Meta<typeof VolumeSliderContainer>;
 
 export default meta;
-type Story = StoryObj<typeof VolumeSlider>;
+type Story = StoryObj<typeof VolumeSliderContainer>;
 
-export const VolumeSliderStory: Story = {
+export const VolumeSliderContainerStory: Story = {
   name: "VolumeSlider",
-  render: (props) => (
+  decorators: [
+    (Story) => (
+      <VolumeSliderContainer>
+        <Story />
+      </VolumeSliderContainer>
+    ),
+  ],
+  render: () => (
     /* 
-    Note: I made a container wrapper due to some quirks with SB background colors 
-      that I don't want to prioritise at present.  
-    */
+      Note: I made a container wrapper due to some quirks with SB background colors 
+        that I don't want to prioritise at present.  
+      */
     <Box
       bg="grayscale.almostBlack"
       padding="2"
@@ -25,10 +32,9 @@ export const VolumeSliderStory: Story = {
       borderRadius={6}
       w="100%"
     >
-      <VolumeSlider {...props} />
+      <VolumeSlider />
     </Box>
   ),
-  args: {},
   parameters: {
     design: config([
       {

--- a/src/components/molecules/VolumeSlider/VolumeSlider.stories.tsx
+++ b/src/components/molecules/VolumeSlider/VolumeSlider.stories.tsx
@@ -1,0 +1,40 @@
+import { Box } from "@chakra-ui/react";
+import { config } from "@storybook/addon-designs";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { VolumeSlider } from "./VolumeSlider";
+
+const meta = {
+  title: "components/VolumeSlider",
+} satisfies Meta<typeof VolumeSlider>;
+
+export default meta;
+type Story = StoryObj<typeof VolumeSlider>;
+
+export const VolumeSliderStory: Story = {
+  name: "VolumeSlider",
+  render: (props) => (
+    /* 
+    Note: I made a container wrapper due to some quirks with SB background colors 
+      that I don't want to prioritise at present.  
+    */
+    <Box
+      bg="grayscale.almostBlack"
+      padding="2"
+      color="white"
+      borderRadius={6}
+      w="100%"
+    >
+      <VolumeSlider {...props} />
+    </Box>
+  ),
+  args: {},
+  parameters: {
+    design: config([
+      {
+        type: "figma",
+        url: "https://www.figma.com/file/HfIFZ2xe4LJgyCSk08SL8I/Player?type=design&node-id=171%3A162&mode=design&t=WK89mzXD1kcI4erK-1",
+      },
+    ]),
+  },
+};

--- a/src/components/molecules/VolumeSlider/VolumeSlider.tsx
+++ b/src/components/molecules/VolumeSlider/VolumeSlider.tsx
@@ -1,30 +1,37 @@
-import { Flex, HStack, VStack } from "@chakra-ui/react";
-import { Timestamp } from "components/atoms/Timestamp";
+import { HStack } from "@chakra-ui/react";
+import { IconButton } from "components/molecules/IconButton";
 import { Slider } from "components/molecules/Slider";
+import { useContext } from "react";
+
+import { VolumeContext } from ".";
+import { pickVolumeIcon } from "./utils";
 
 const ARIA_LABEL = "Volume slider handle";
 
-interface VolumeSliderProps {
-  /* From 0 - 1 (0 meaning muted & 1 being full volume) */
-  volume: number;
-  onVolumeChange: (value: number) => void;
-  isMuted?: boolean;
-  toggleMute: (mute: boolean) => void;
-}
+export function VolumeSlider() {
+  const {
+    volume,
+    onVolumeChange,
+    toggleMute,
+    muted = false,
+  } = useContext(VolumeContext);
 
-export function VolumeSlider({
-  volume,
-  onVolumeChange,
-  isMuted,
-  toggleMute,
-}: VolumeSliderProps) {
   return (
-    <Slider
-      aria-label={ARIA_LABEL}
-      onChange={onVolumeChange}
-      value={volume}
-      min={0}
-      max={1}
-    />
+    <HStack role="group">
+      <IconButton
+        aria-label="Mute Track"
+        size="md"
+        icon={pickVolumeIcon(volume, muted)}
+        onClick={() => toggleMute()}
+      />
+      <Slider
+        aria-label={ARIA_LABEL}
+        onChange={onVolumeChange}
+        value={muted ? 0 : volume}
+        step={0.05}
+        min={0}
+        max={1}
+      />
+    </HStack>
   );
 }

--- a/src/components/molecules/VolumeSlider/VolumeSlider.tsx
+++ b/src/components/molecules/VolumeSlider/VolumeSlider.tsx
@@ -1,0 +1,30 @@
+import { Flex, HStack, VStack } from "@chakra-ui/react";
+import { Timestamp } from "components/atoms/Timestamp";
+import { Slider } from "components/molecules/Slider";
+
+const ARIA_LABEL = "Volume slider handle";
+
+interface VolumeSliderProps {
+  /* From 0 - 1 (0 meaning muted & 1 being full volume) */
+  volume: number;
+  onVolumeChange: (value: number) => void;
+  isMuted?: boolean;
+  toggleMute: (mute: boolean) => void;
+}
+
+export function VolumeSlider({
+  volume,
+  onVolumeChange,
+  isMuted,
+  toggleMute,
+}: VolumeSliderProps) {
+  return (
+    <Slider
+      aria-label={ARIA_LABEL}
+      onChange={onVolumeChange}
+      value={volume}
+      min={0}
+      max={1}
+    />
+  );
+}

--- a/src/components/molecules/VolumeSlider/VolumeSliderContainer.tsx
+++ b/src/components/molecules/VolumeSlider/VolumeSliderContainer.tsx
@@ -1,0 +1,66 @@
+// VolumeSliderContainer
+// Note: This is not the finalised way of doing this as ideally state will be
+//   centralised/ provided by the Player. This is more of an intermediary step to
+//   show how it could eventually work.
+import React, { createContext, useState } from "react";
+
+const DEFAULT_VOLUME = 0.7;
+
+type VolumeContext = {
+  /* From 0 - 1 (0 meaning muted & 1 being full volume) */
+  volume: number;
+  onVolumeChange: (volume: number) => void;
+  muted: boolean;
+  toggleMute: () => void;
+};
+
+export const VolumeContext = createContext<VolumeContext>({
+  volume: DEFAULT_VOLUME,
+  onVolumeChange: () => {},
+  muted: false,
+  toggleMute: () => {},
+});
+
+export const VolumeSliderContainer = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [volume, setVolume] = useState(DEFAULT_VOLUME);
+  const [muted, setMuted] = useState(false);
+
+  const toggleMute = () => {
+    const shouldMute = !muted;
+
+    if (shouldMute === false && volume === 0) {
+      setMuted(false);
+      setVolume(DEFAULT_VOLUME);
+    } else {
+      setMuted(shouldMute);
+    }
+  };
+
+  const onVolumeChange = (vol: number) => {
+    if (vol === volume) {
+      return;
+    }
+
+    if (muted && vol !== 0) {
+      setMuted(false);
+    }
+
+    if (vol === 0) {
+      setMuted(true);
+    }
+
+    setVolume(vol);
+  };
+
+  return (
+    <VolumeContext.Provider
+      value={{ volume, onVolumeChange, muted, toggleMute }}
+    >
+      {children}
+    </VolumeContext.Provider>
+  );
+};

--- a/src/components/molecules/VolumeSlider/index.ts
+++ b/src/components/molecules/VolumeSlider/index.ts
@@ -1,0 +1,1 @@
+export * from "./VolumeSlider";

--- a/src/components/molecules/VolumeSlider/index.ts
+++ b/src/components/molecules/VolumeSlider/index.ts
@@ -1,1 +1,2 @@
 export * from "./VolumeSlider";
+export * from "./VolumeSliderContainer";

--- a/src/components/molecules/VolumeSlider/utils/index.ts
+++ b/src/components/molecules/VolumeSlider/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./pickVolumeIcon";

--- a/src/components/molecules/VolumeSlider/utils/pickVolumeIcon.ts
+++ b/src/components/molecules/VolumeSlider/utils/pickVolumeIcon.ts
@@ -1,0 +1,12 @@
+import { AllIcons } from "components/atoms/Icon";
+
+export const pickVolumeIcon = (volume: number, isMuted: boolean) => {
+  if (isMuted || volume === 0) {
+    return AllIcons.VolumeMuted;
+  } else if (volume > 0 && volume <= 0.33) {
+    return AllIcons.VolumeLow;
+  } else if (volume > 0.33 && volume <= 0.66) {
+    return AllIcons.VolumeMedium;
+  }
+  return AllIcons.VolumeHigh;
+};


### PR DESCRIPTION
closes #11 

<img width="674" alt="image" src="https://github.com/JonnyPickard/react-audio-player/assets/16156445/5942edbd-174a-4ccc-bda5-c48ee89165dc">

<img width="688" alt="image" src="https://github.com/JonnyPickard/react-audio-player/assets/16156445/3e8c58e7-62ab-497b-868a-3921141ecfd0">


Mute toggle button:

If muted show muted icon.
At different volume steps show different loudness volume icon variants.
Logic for unmute

If previous volume 0 + unmute clicked = jump to default volume
If previous volume > 0 + unmute clicked = jump to previous volume